### PR TITLE
Use first folder as cwd for git grep

### DIFF
--- a/searchengines/base.py
+++ b/searchengines/base.py
@@ -32,8 +32,10 @@ class Base:
             by a semicolon, and the second element is the result string
         """
         command_line = self._command_line(query, folders)
+        workingFolder = folders[0][1:-1]   # Nasty hack to get the first folder and remove surrounding quotes
+        print("Running in working folder: %s" % workingFolder)
         print("Running: %s" % command_line)
-        pipe = subprocess.Popen(command_line, shell=True, stdout=subprocess.PIPE)
+        pipe = subprocess.Popen(command_line, shell=True, stdout=subprocess.PIPE, cwd=workingFolder)
         output, error = pipe.communicate()
         if pipe.returncode != 0:
             return None


### PR DESCRIPTION
The git-grep search did not work for me on Windows (it may on other O/Ses) because git on Windows must be run with its working directory set to a directory within the repository to search. There are no arguments you can pass to search from outside a repository.

I am not particularly happy with the fix, but am 100% open to suggestions on how I can improve it. Bear in mind that my python skillz are non existent and this is the first Sublime plugin I've edited. This fix will not work where folders in the project span multiple repositories. Making it work would probably require detecting the different repositories, executing git grep multiple times, and combining the results. I also do not like the method of removing quotes - it would be better to pass in an unquoted folder string.

However: this simple works for my simple scenario.