### PR TITLE
Correctly quote queries so that users don't have to

### DIFF
--- a/searchengines/base.py
+++ b/searchengines/base.py
@@ -47,7 +47,7 @@ class Base:
             self.path_to_executable,
             self.mandatory_options,
             self.common_options,
-            query
+            "'" + query.replace("'", "'\\''") + "'"
         ] + folders)
 
     def _sanitize_output(self, output):


### PR DESCRIPTION
This solves the quoted query problem where users would have to escape and quote their search text as though running it on the command-line.
