### PR TITLE
Fixed Ubuntu version check

### DIFF
--- a/searchengines/ack.py
+++ b/searchengines/ack.py
@@ -22,7 +22,7 @@ class Ack (base.Base):
     def __init__(self, settings):
         base.Base.__init__(self, settings)
         # Ubuntu's ack from repos is called ack-grep by default
-        if 'Ubuntu' in os.uname().version and self.path_to_executable=='ack' and os.system('which ack-grep')==0:
+        if 'Ubuntu' in os.uname()[3] and self.path_to_executable=='ack' and os.system('which ack-grep')==0:
             self.path_to_executable = 'ack-grep'
 
 engine_class = Ack


### PR DESCRIPTION
This code works with Python 2 and 3. Only the Python 3 version of `os.uname()`
returns an object with the version attribute - in Python 2 it's just a tuple.
But for backwards compatibility, the Python 3 object is also iterable, behaving
like a five-tuple containing `sysname`, `nodename`, `release`, `version`, and `machine`
in that order.