### PR TITLE
Allow per-project settings to override package settings

### DIFF
--- a/search_in_project.py
+++ b/search_in_project.py
@@ -33,14 +33,14 @@ class SearchInProjectCommand(sublime_plugin.WindowCommand):
         pass
 
     def run(self):
+        view = self.window.active_view()
         self.settings = sublime.load_settings('SearchInProject.sublime-settings')
-        self.engine_name = self.settings.get("search_in_project_engine")
+        self.engine_name = view.settings().get("search_in_project_engine", self.settings.get("search_in_project_engine"))
         pushd = os.getcwd()
         os.chdir(basedir)
         __import__("searchengines.%s" % self.engine_name)
-        self.engine = searchengines.__dict__[self.engine_name].engine_class(self.settings)
+        self.engine = searchengines.__dict__[self.engine_name].engine_class(self.settings, view)
         os.chdir(pushd)
-        view = self.window.active_view()
         selection_text = view.substr(view.sel()[0])
         self.window.show_input_panel(
             "Search in project:",

--- a/searchengines/base.py
+++ b/searchengines/base.py
@@ -18,13 +18,13 @@ class Base:
 
     HAS_COLUMN_INFO = re.compile('^[^:]+:\d+:\d+:')
 
-    def __init__(self, settings):
+    def __init__(self, settings, view):
         """
             Receives the sublime.Settings object
         """
         self.settings = settings
         for setting_name in self.__class__.SETTINGS:
-            setting_value = self.settings.get(self._full_settings_name(setting_name), '')
+            setting_value = view.settings().get(self._full_settings_name(setting_name), self.settings.get(self._full_settings_name(setting_name), ''))
             if sys.version < '3':
                 setting_value = setting_value.encode()
             setattr(self, setting_name, setting_value)


### PR DESCRIPTION
This is a simple patch that allows per-project settings.  Mainly, it's helpful for being able to exclude subdirectories you don't want on a per-project basis.  To use it, stick something like this in your .sublime-project file:

```
{
    "settings":
    {
          "search_in_project_engine": "the_silver_searcher",
          "search_in_project_TheSilverSearcher_common_options": "--ignore node_modules --ignore public/js/libs --ignore binaries"
    }
}
```

Options specified in the project file will override User settings; so you could for example have search_in_project_engine in User settings for the package, and then in each project include directory exclusions/inclusions, file types to search, etc, etc on a per-project basis.
