### PR TITLE
Escape the regex

### DIFF
--- a/search_in_project.py
+++ b/search_in_project.py
@@ -4,6 +4,7 @@ import os.path
 import os
 import sys
 import inspect
+import re
 
 ### Start of fixing import paths
 # realpath() with make your script run, even if you symlink it :)
@@ -44,7 +45,7 @@ class SearchInProjectCommand(sublime_plugin.WindowCommand):
         selection_text = view.substr(view.sel()[0])
         self.window.show_input_panel(
             "Search in project:",
-            not "\n" in selection_text and selection_text or self.last_search_string,
+            not "\n" in selection_text and re.escape(selection_text) or self.last_search_string,
             self.perform_search, None, None)
         pass
 


### PR DESCRIPTION
Tiny little patch which escapes regex-special characters that were on the search clipboard.  Too many times have I selected some piece of code, hit cmd-e then cmd-opt-shift-f, enter and had an error cos the code I'd selected has special regex characters in it like ( or \* that I didn't escape.  Now they're escaped automatically.
