### PR TITLE
Avoid showing console window on Windows platform

### DIFF
--- a/searchengines/base.py
+++ b/searchengines/base.py
@@ -41,10 +41,13 @@ class Base:
         print("Running: %s" % " ".join(arguments))
 
         try:
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
             pipe = subprocess.Popen(arguments,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                cwd=folders[0]
+                cwd=folders[0],
+                startupinfo=startupinfo
                 )
         except OSError: # Not FileNotFoundError for compatibility with Sublime Text 2
             raise RuntimeError("Could not find executable %s" % self.path_to_executable)
@@ -86,7 +89,9 @@ class Base:
 
     def _resolve_windows_path_to_executable(self):
         try:
-            self.path_to_executable = self._sanitize_output(subprocess.check_output("where %s" % self.path_to_executable))
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            self.path_to_executable = self._sanitize_output(subprocess.check_output("where %s" % self.path_to_executable, startupinfo=startupinfo))
         except subprocess.CalledProcessError:
             # do nothing, executable not found
             pass

--- a/searchengines/base.py
+++ b/searchengines/base.py
@@ -41,8 +41,11 @@ class Base:
         print("Running: %s" % " ".join(arguments))
 
         try:
-            startupinfo = subprocess.STARTUPINFO()
-            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            startupinfo = None
+            if os.name == 'nt':
+                startupinfo = subprocess.STARTUPINFO()
+                startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
             pipe = subprocess.Popen(arguments,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
This is to fix console window appearing on Windows all the time when using the plugin.

Note I wasn't able to test it on other platforms, maybe the code should be if-ed. But if I'm reading the docs correctly the extra parameter should be simply ignored on non-windows platforms.