### PR TITLE
Crop extra-long lines to fix #20

### DIFF
--- a/search_in_project.py
+++ b/search_in_project.py
@@ -60,7 +60,7 @@ class SearchInProjectCommand(sublime_plugin.WindowCommand):
         try:
             self.results = self.engine.run(text, folders)
             if self.results:
-                self.results = [[result[0].replace(self.common_path.replace('\"', ''), ''), result[1]] for result in self.results]
+                self.results = [[result[0].replace(self.common_path.replace('\"', ''), ''), result[1][:1000]] for result in self.results]
                 self.results.append("``` List results in view ```")
                 self.window.show_quick_panel(self.results, self.goto_result)
             else:


### PR DESCRIPTION
With really long lines (e. g. minified js in git repositories) the IDE hangs for good when scrolling through results as described in #20.

This update only gives first 1000 characters for display in IDE, which fixes most of the problem while arguably not really hurting anyone.