### PR TITLE
Fixed results on Windows

### DIFF
--- a/search_in_project.py
+++ b/search_in_project.py
@@ -60,7 +60,7 @@ class SearchInProjectCommand(sublime_plugin.WindowCommand):
         try:
             self.results = self.engine.run(text, folders)
             if self.results:
-                self.results = [[result[0].replace(self.common_path.replace('\"', ''), ''), result[1]] for result in self.results]
+                self.results = [[result[0].replace(self.common_path, ''), result[1]] for result in self.results]
                 self.results.append("``` List results in view ```")
                 self.window.show_quick_panel(self.results, self.goto_result)
             else:
@@ -76,7 +76,7 @@ class SearchInProjectCommand(sublime_plugin.WindowCommand):
             if file_no == len(self.results) - 1: # last result is "list in view"
                 self.list_in_view()
             else:
-                file_name = self.common_path.replace('\"', '') + self.results[file_no][0]
+                file_name = self.common_path + self.results[file_no][0]
                 view = self.window.open_file(file_name, sublime.ENCODED_POSITION)
                 regions = view.find_all(self.last_search_string)
                 view.add_regions("search_in_project", regions, "entity.name.filename.find-in-files", "circle", sublime.DRAW_OUTLINED)
@@ -87,7 +87,7 @@ class SearchInProjectCommand(sublime_plugin.WindowCommand):
         view.run_command('search_in_project_results',
             {'query': self.last_search_string,
              'results': self.results,
-             'common_path': self.common_path.replace('\"', '')})
+             'common_path': self.common_path})
 
     def search_folders(self):
         search_folders = self.window.folders()
@@ -101,7 +101,7 @@ class SearchInProjectCommand(sublime_plugin.WindowCommand):
 
     def find_common_path(self, paths):
         paths = [path.replace("\"", "") for path in paths]
-        paths = [path.split("/") for path in paths]
+        paths = [path.split(os.path.sep) for path in paths]
         common_path = []
         while 0 not in [len(path) for path in paths]:
             next_segment = list(set([path.pop(0) for path in paths]))
@@ -109,7 +109,7 @@ class SearchInProjectCommand(sublime_plugin.WindowCommand):
                 common_path += next_segment
             else:
                 break
-        return "\"" + "/".join(common_path) + "/\""
+        return os.path.sep.join(common_path) + os.path.sep
 
 class SearchInProjectResultsCommand(sublime_plugin.TextCommand):
     def format_result(self, common_path, filename, lines):


### PR DESCRIPTION
I'm using this plugin with `ag` a.k.a. `The Silver Searcher` on Windows, and while it shows the search results, it is unable to open them (you'll get an empty file named `C` or whatever you drive letter is). This happens because the line with the match info is separated on colons, and on Windows you have an extra colon in the path after the drive name, which messes with the current logic of generating results. This PR makes this logic cross-platform.
