### PR TITLE
Add new option to go straight to the list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for SearchInProject
 
+## Upcoming
+
+* Add new option `search_in_project_show_list_by_default` to skip the quick panel and go straight to the list view
+
 ## v1.8.0 2016-10-31
 
 * Support Ripgrep

--- a/SearchInProject.sublime-settings
+++ b/SearchInProject.sublime-settings
@@ -7,6 +7,7 @@
   /* The default is grep because it's widely available on *nix machines, but ack and The Silver Searcher are both faster, */
   /* and git grep is also faster, but only works inside a Git repository */
   "search_in_project_engine": "grep",
+  "search_in_project_show_list_by_default": "false",
 
   /* Grep configuration */
   /* Path to grep executable; if the standard one doesn't work for you, you can specify an explicit path in your user config file. */

--- a/search_in_project.py
+++ b/search_in_project.py
@@ -66,8 +66,11 @@ class SearchInProjectCommand(sublime_plugin.WindowCommand):
             self.results = self.engine.run(text, folders)
             if self.results:
                 self.results = [[result[0].replace(self.common_path.replace('\"', ''), ''), result[1][:self.MAX_RESULT_LINE_LENGTH]] for result in self.results]
-                self.results.append("``` List results in view ```")
-                self.window.show_quick_panel(self.results, self.goto_result)
+                if self.settings.get('search_in_project_show_list_by_default') == 'true':
+                    self.list_in_view()
+                else:
+                    self.results.append("``` List results in view ```")
+                    self.window.show_quick_panel(self.results, self.goto_result)
             else:
                 self.results = []
                 sublime.message_dialog('No results')


### PR DESCRIPTION
>This allows SearchInProject to act identically to SublimeText's search
by immediately showing the Find Results view. This must be turned on to
`true`; by default it is off, so no change in functionality.